### PR TITLE
Use jsone 1.4.7 - erlang:get_stacktrace deprecated - otp 22 support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 {deps, [
         {cowboy, "1.0.4"},
         base64url,
-        {jsone, "1.4.0"},
+        {jsone, "1.4.7"},
         oidcc
        ]
 }.


### PR DESCRIPTION

erlang:get_stacktrace used in jsone 1.4.0 is  deprecated in OTP 22 

- Use jsone 1.4.7 for OTP 22 support 
- Relevant EEP is at  https://www.erlang.org/erlang-enhancement-proposals/eep-0047.html 