### PR TITLE
Get scope for callback from request or from opts

### DIFF
--- a/src/oidcc_cowboy_callback.erl
+++ b/src/oidcc_cowboy_callback.erl
@@ -141,15 +141,16 @@ init(Req, Opts) ->
         ok ?= check_peer_ip(Req, PeerIp, CheckPeerId),
         ok ?= check_useragent(Req, Useragent, CheckUseragent),
         {ok, Code} ?= fetch_request_param(<<"code">>, RequestParams),
-        {ok, Scopes} ?= case fetch_request_param(<<"scope">>, RequestParams) of
-                            {ok, Scope} ->
-                                {ok, oidcc_scope:parse(Scope)};
-                            _ ->
-                                case maps:get(scopes, Opts, undefined) of
-                                    [_ | _] = Scps -> {ok, Scps};
-                                    _ -> {error, {missing_request_param, <<"scope">>}}
-                                end
-                        end,
+        {ok, Scopes} ?=
+            case fetch_request_param(<<"scope">>, RequestParams) of
+                {ok, Scope} ->
+                    {ok, oidcc_scope:parse(Scope)};
+                _ ->
+                    case maps:get(scopes, Opts, undefined) of
+                        [_ | _] = Scps -> {ok, Scps};
+                        _ -> {error, {missing_request_param, <<"scope">>}}
+                    end
+            end,
         TokenOpts = maps:merge(
             #{nonce => Nonce, scope => Scopes, pkce_verifier => PkceVerifier},
             maps:with([redirect_uri, pkce, request_opts], Opts)

--- a/src/oidcc_cowboy_callback.erl
+++ b/src/oidcc_cowboy_callback.erl
@@ -57,7 +57,7 @@
     check_useragent => boolean(),
     check_peer_ip => boolean(),
     retrieve_userinfo => boolean(),
-    scopes => [oidcc_scope:scopes()],
+    scopes => oidcc_scope:scopes(),
     request_opts => oidcc_http_util:request_opts(),
     handle_success := fun(
         (
@@ -85,7 +85,7 @@
 %%   <li>`check_peer_ip' - check if the client IP is the same as before the
 %%     authorization request</li>
 %%   <li>`retrieve_userinfo' - whether to load userinfo from the provider</li>
-%%   <li>`scopes' - list of scopes to use in token request (if not present in Req); defaults to `[<<"openid">>]'</li>
+%%   <li>`scopes' - list of scopes to use in token request (if not present in Req); defaults to `[openid]'</li>
 %%   <li>`request_opts' - request opts for http calls to provider</li>
 %%   <li>`handle_success' - handler to react to successful token retrieval
 %%     (render response etc.)</li>
@@ -147,7 +147,7 @@ init(Req, Opts) ->
                             _ ->
                                 case maps:get(scopes, Opts, [openid]) of
                                     [_ | _] = Scps ->
-                                        {ok, lists:map(fun normalize_scope/1, Scps)};
+                                        {ok, Scps};
                                     _ ->
                                         {error, invalid_scopes}
                                 end
@@ -234,11 +234,3 @@ retrieve_userinfo(Token, ProviderId, ClientId, ClientSecret, true) ->
 %% @private
 terminate(_Reason, _Req, _State) ->
     ok.
-
-normalize_scope(Scope) when is_binary(Scope) ->
-    Scope;
-normalize_scope(Scope) when is_atom(Scope) ->
-    atom_to_binary(Scope, utf8);
-normalize_scope(Scope) when is_list(Scope) ->
-    list_to_binary(Scope).
-

--- a/src/oidcc_cowboy_callback.erl
+++ b/src/oidcc_cowboy_callback.erl
@@ -85,7 +85,7 @@
 %%   <li>`check_peer_ip' - check if the client IP is the same as before the
 %%     authorization request</li>
 %%   <li>`retrieve_userinfo' - whether to load userinfo from the provider</li>
-%%   <li>`scopes' - list of scopes to use in token request (if not present in Req); defaults to `[openid]'</li>
+%%   <li>`scopes' - list of scopes to use in token request (if not present in Req)</li>
 %%   <li>`request_opts' - request opts for http calls to provider</li>
 %%   <li>`handle_success' - handler to react to successful token retrieval
 %%     (render response etc.)</li>
@@ -145,11 +145,9 @@ init(Req, Opts) ->
                             {ok, Scope} ->
                                 {ok, oidcc_scope:parse(Scope)};
                             _ ->
-                                case maps:get(scopes, Opts, [openid]) of
-                                    [_ | _] = Scps ->
-                                        {ok, Scps};
-                                    _ ->
-                                        {error, invalid_scopes}
+                                case maps:get(scopes, Opts, undefined) of
+                                    [_ | _] = Scps -> {ok, Scps};
+                                    _ -> {error, {missing_request_param, <<"scope">>}}
                                 end
                         end,
         TokenOpts = maps:merge(

--- a/src/oidcc_cowboy_callback.erl
+++ b/src/oidcc_cowboy_callback.erl
@@ -46,6 +46,7 @@
     | oidcc_userinfo:error()
     | useragent_mismatch
     | peer_ip_mismatch
+    | invalid_scopes
     | {missing_request_param, Param :: binary()}.
 
 -type opts() :: #{
@@ -56,6 +57,7 @@
     check_useragent => boolean(),
     check_peer_ip => boolean(),
     retrieve_userinfo => boolean(),
+    scopes => [oidcc_scope:scopes()],
     request_opts => oidcc_http_util:request_opts(),
     handle_success := fun(
         (
@@ -83,6 +85,7 @@
 %%   <li>`check_peer_ip' - check if the client IP is the same as before the
 %%     authorization request</li>
 %%   <li>`retrieve_userinfo' - whether to load userinfo from the provider</li>
+%%   <li>`scopes' - list of scopes to use in token request (if not present in Req); defaults to `[<<"openid">>]'</li>
 %%   <li>`request_opts' - request opts for http calls to provider</li>
 %%   <li>`handle_success' - handler to react to successful token retrieval
 %%     (render response etc.)</li>
@@ -142,9 +145,11 @@ init(Req, Opts) ->
                             {ok, Scope} ->
                                 {ok, oidcc_scope:parse(Scope)};
                             _ ->
-                                case maps:get(scopes, Opts, undefined) of
-                                    [_ | _] = Scps -> {ok, lists:map(fun atom_to_binary/1, Scps)};
-                                    _ -> {error, {missing_request_param, <<"scope">>}}
+                                case maps:get(scopes, Opts, [openid]) of
+                                    [_ | _] = Scps ->
+                                        {ok, lists:map(fun normalize_scope/1, Scps)};
+                                    _ ->
+                                        {error, invalid_scopes}
                                 end
                         end,
         TokenOpts = maps:merge(
@@ -229,3 +234,11 @@ retrieve_userinfo(Token, ProviderId, ClientId, ClientSecret, true) ->
 %% @private
 terminate(_Reason, _Req, _State) ->
     ok.
+
+normalize_scope(Scope) when is_binary(Scope) ->
+    Scope;
+normalize_scope(Scope) when is_atom(Scope) ->
+    atom_to_binary(Scope, utf8);
+normalize_scope(Scope) when is_list(Scope) ->
+    list_to_binary(Scope).
+


### PR DESCRIPTION
`oidcc_cowboy_callback` requires `scope` to be present in successful authentication response redirect, while according to OpenID Connect Core 1.0 and RFC6749 it is not required (and, for instance, Keycloak doesn't return it). We could therefore allow for it to be missing and let the client specify it in callback options.
